### PR TITLE
Fix TypeError when using methods for a mismatched country identifier

### DIFF
--- a/lib/countryjs.js
+++ b/lib/countryjs.js
@@ -18,38 +18,35 @@ var Country = function () {
     var _returnData
     switch (type) {
     case 'name':
-      _returnData = _.filter(_countryList, {
+      _returnData = _.find(_countryList, {
         name: country
-      })[0]
+      })
       if (_.isUndefined(_returnData)) {
-        _returnData = _.filter(_countryList, function (obj) {
+        _returnData = _.find(_countryList, function (obj) {
           return _.indexOf(obj.altSpellings, country) > -1
-        })[0]
+        })
       }
       if (_.isUndefined(_returnData)) {
-        _returnData = _.filter(_countryList, function (obj) {
+        _returnData = _.find(_countryList, function (obj) {
           return _.indexOf(_.values(obj.translations), country) > -1
-        })[0]
+        })
       }
       break
     case 'ISO3':
-      _returnData = _.filter(_countryList, function (obj) {
+      _returnData = _.find(_countryList, function (obj) {
         return obj.ISO.alpha3 === country
-      })[0]
+      })
       break
     case 'ISO2':
-      _returnData = _.filter(_countryList, function (obj) {
+      _returnData = _.find(_countryList, function (obj) {
         return obj.ISO.alpha2 === country
-      })[0]
+      })
       break
     default:
-      _returnData = _.filter(_countryList, function (obj) {
+      _returnData = _.find(_countryList, function (obj) {
         return obj.ISO.alpha2 === country
-      })[0]
+      })
       break
-    }
-    if (_.isUndefined(_returnData)) {
-      return undefined
     }
     return _returnData
   }

--- a/lib/countryjs.js
+++ b/lib/countryjs.js
@@ -63,118 +63,164 @@ var Country = function () {
   }
   this.name = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.name
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.name
+      return _returnData
+    }
   }
   this.states = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.provinces
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.provinces
+      return _returnData
+    }
   }
   this.provinces = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.provinces
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.provinces
+      return _returnData
+    }
   }
   this.altSpellings = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.altSpellings
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.altSpellings
+      return _returnData
+    }
   }
   this.area = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.area
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.area
+      return _returnData
+    }
   }
   this.borders = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.borders
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.borders
+      return _returnData
+    }
   }
   this.callingCodes = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.callingCodes
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.callingCodes
+      return _returnData
+    }
   }
   this.capital = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.capital
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.capital
+      return _returnData
+    }
   }
   this.currencies = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.currencies
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.currencies
+      return _returnData
+    }
   }
   this.demonym = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.demonym
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.demonym
+      return _returnData
+    }
   }
   this.flag = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.flag
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.flag
+      return _returnData
+    }
   }
   this.geoJSON = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.geoJSON
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.geoJSON
+      return _returnData
+    }
   }
   this.ISOcodes = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.ISO
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.ISO
+      return _returnData
+    }
   }
   this.languages = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.languages
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.languages
+      return _returnData
+    }
   }
   this.latlng = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.latlng
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.latlng
+      return _returnData
+    }
   }
   this.nativeName = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.nativeName
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.nativeName
+      return _returnData
+    }
   }
   this.population = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.population
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.population
+      return _returnData
+    }
   }
   this.region = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.region
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.region
+      return _returnData
+    }
   }
   this.subregion = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.subregion
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.subregion
+      return _returnData
+    }
   }
   this.timezones = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.timezones
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.timezones
+      return _returnData
+    }
   }
   this.tld = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.tld
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.tld
+      return _returnData
+    }
   }
   this.translations = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.translations
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.translations
+      return _returnData
+    }
   }
   this.wiki = function (country, type) {
     var _returnData = _returnCountry(country, type)
-    _returnData = _returnData.wiki
-    return _returnData
+    if (_returnData) {
+      _returnData = _returnData.wiki
+      return _returnData
+    }
   }
   return this
 }

--- a/test/countryjs.test.js
+++ b/test/countryjs.test.js
@@ -182,5 +182,9 @@ describe('countryjs', function () {
     expect(tester).to.be.an('undefined')
     done()
   })
-
+  it('should undefined for a mismatched country identifier (other methods)', function (done) {
+    var tester = country.name('UX')
+    expect(tester).to.be.an('undefined')
+    done()
+  })
 })

--- a/test/countryjs.test.js
+++ b/test/countryjs.test.js
@@ -183,8 +183,35 @@ describe('countryjs', function () {
     done()
   })
   it('should undefined for a mismatched country identifier (other methods)', function (done) {
-    var tester = country.name('UX')
-    expect(tester).to.be.an('undefined')
+    var methods = [
+      'states',
+      'provinces',
+      'name',
+      'altSpellings',
+      'area',
+      'borders',
+      'callingCodes',
+      'capital',
+      'currencies',
+      'demonym',
+      'flag',
+      'geoJSON',
+      'ISOcodes',
+      'languages',
+      'latlng',
+      'nativeName',
+      'population',
+      'region',
+      'subregion',
+      'timezones',
+      'tld',
+      'translations',
+      'wiki'
+    ]
+    methods.forEach(function (method) {
+      var tester = country[method]('UX')
+      expect(tester).to.be.an('undefined')
+    })
     done()
   })
 })


### PR DESCRIPTION
Using any API methods (except `info`) for a mismatched country identifier, like `country.name('UX')`, throws a `TypeError: Cannot read property 'name' of undefined`.
Add a test on the returned objects before calling properties on them.