### PR TITLE
Add support for approximate string matching of country name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Node.js module for returning data about countries, ISO info and states/provinc
 
 * [Install](#install)
   * [Using with browserify](#browserify)
+* [Usage](#usage)
 * [API](#api)
   * [`.info()`](#info)
   * [`.states()`](#states)
@@ -71,6 +72,14 @@ var bundle = browserify({
   global: true
 })
 ```
+
+## Usage
+
+To access one of the country properties available, you'll need to use one of the API methods listed below and pass a country in either way:
+
+- Using the ISO-alpha2 code: `country.population('US', 'ISO2')` or `country.area('JP')` (defaults)
+- Using the ISO-alpha3 code: `country.capital('GBR', 'ISO3)`
+- Using the country name: `country.wiki('france', 'name')`. The matching is case-insensitive, against the native name, alternative spellings and available transalations.
 
 ## API
 
@@ -546,6 +555,3 @@ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR 
 INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
-
-
-

--- a/lib/countryjs.js
+++ b/lib/countryjs.js
@@ -12,26 +12,32 @@
 // ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 var _ = require('lodash')
-var Fuse = require('fuse.js')
 var _countryList = require('../data')()
-var fuse = new Fuse(_countryList, {keys: ['name', 'altSpellings', 'translations']})
+var normalizeName = function (name) {
+  return _.deburr(name)
+    .toLowerCase()
+    .replace(/\-/g, ' ')
+    .replace(/(\.|\b(the|and|of|de|des|du|di|del|y|da|und|die) \b)/g, '')
+    .trim()
+}
+var findIndex = _.transform(_countryList, function (index, country, key) {
+  var addToIndex = function (name) {
+    if (name) {
+      index[normalizeName(name)] = key
+    }
+  }
+  addToIndex(country.name)
+  _.forEach(country.altSpellings, addToIndex)
+  _.forEach(country.translations, addToIndex)
+})
 var Country = function () {
   var _returnCountry = function (country, type) {
     var _returnData
     switch (type) {
     case 'name':
-      _returnData = _.find(_countryList, {
-        name: country
-      })
-      if (_.isUndefined(_returnData)) {
-        _returnData = _.find(_countryList, function (obj) {
-          return _.indexOf(obj.altSpellings, country) > -1
-        })
-      }
-      if (_.isUndefined(_returnData)) {
-        _returnData = _.find(_countryList, function (obj) {
-          return _.indexOf(_.values(obj.translations), country) > -1
-        })
+      var key = findIndex[normalizeName(country)]
+      if (!_.isUndefined(key)) {
+        _returnData = _countryList[key]
       }
       break
     case 'ISO3':
@@ -59,9 +65,6 @@ var Country = function () {
   this.info = function (country, type) {
     var _returnData = _returnCountry(country, type)
     return _returnData
-  }
-  this.search = function (country) {
-    return fuse.search(country)
   }
   this.name = function (country, type) {
     var _returnData = _returnCountry(country, type)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/therebelrobot/countryjs",
   "dependencies": {
     "bulk-require": "^0.2.1",
-    "fuse.js": "1.3.1",
     "lodash": "^3.3.1"
   },
   "devDependencies": {

--- a/test/countryjs.test.js
+++ b/test/countryjs.test.js
@@ -183,8 +183,35 @@ describe('countryjs', function () {
     done()
   })
   it('should undefined for a mismatched country identifier (other methods)', function (done) {
-    var tester = country.name('UX')
-    expect(tester).to.be.an('undefined')
+    var methods = [
+      'states',
+      'provinces',
+      'name',
+      'altSpellings',
+      'area',
+      'borders',
+      'callingCodes',
+      'capital',
+      'currencies',
+      'demonym',
+      'flag',
+      'geoJSON',
+      'ISOcodes',
+      'languages',
+      'latlng',
+      'nativeName',
+      'population',
+      'region',
+      'subregion',
+      'timezones',
+      'tld',
+      'translations',
+      'wiki'
+    ]
+    methods.forEach(function (method) {
+      var tester = country[method]('UX')
+      expect(tester).to.be.an('undefined')
+    })
     done()
   })
 })

--- a/test/countryjs.test.js
+++ b/test/countryjs.test.js
@@ -42,17 +42,17 @@ describe('countryjs', function () {
     expect(tester).to.be.an('object')
     done()
   })
-  it('should get list of countries using fuzzy search', function (done) {
+  it('should get all available info using approximate string matching', function (done) {
     var searches = {
       'thailande': 'Thailand',
       'U.S.A': 'United States',
-      'THE GREAT BRITAIN': 'United Kingdom'
+      'THE GREAT BRITAIN': 'United Kingdom',
+      ' Bosnia herzegovina ': 'Bosnia and Herzegovina'
     }
     Object.keys(searches).forEach(function (search) {
-      var tester = country.search(search)
-      expect(tester).to.be.an('array')
-      expect(tester).to.not.be.empty
-      expect(tester[0].name).to.equal(searches[search])
+      var tester = country.info(search, 'name')
+      expect(tester).to.be.an('object')
+      expect(tester.name).to.equal(searches[search])
     })
     done()
   })


### PR DESCRIPTION
Hi again,
This is a fix I do need for my own use cases. So feel free to reject it if you think it might bloat the library. But I think it could be quite useful to others.
It makes the matching insensitive to the case, diacritics, the presence of small words (of, the, end, ...) or some characters like "-" and ".".
It does not have any performance impact since I do build an index at start (It might even be a bit faster).
Have a look at the new test case to see some examples of matching that was not possible before.

(Sorry for the multiple commits, at first I was using an external fuzzy matching library but results were too inaccurate)