### PR TITLE
Change the bulk require to use Webpack's request.context

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -11,8 +11,8 @@
 // DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 // ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-function requireAll(requireContext) {
-  return requireContext.keys().map(requireContext);
+function requireAll (requireContext) {
+  return requireContext.keys().map(requireContext)
 }
 
 var fileList = requireAll(require.context(__dirname, true, /.*json$/))

--- a/data/index.js
+++ b/data/index.js
@@ -11,12 +11,15 @@
 // DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 // ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-var bulkify = require('bulk-require')
+function requireAll(requireContext) {
+  return requireContext.keys().map(requireContext);
+}
+
+var fileList = requireAll(require.context(__dirname, true, /.*json$/))
 var _ = require('lodash')
 
 module.exports = function () {
   var totalList = []
-  var fileList = bulkify(__dirname, ['*.json'])
   _.forEach(fileList, function (file) {
     file.ISO[2] = file.ISO.alpha2
     file.ISO[3] = file.ISO.alpha3

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "homepage": "https://github.com/therebelrobot/countryjs",
   "dependencies": {
-    "bulk-require": "^0.2.1",
     "lodash": "^4.2.1",
     "minimatch": "^3.0.3"
   },


### PR DESCRIPTION
From what I can tell, this module doesn't work in Webpack because of the bulk-require module, and can be fixed by using Webpack's `require.context`.

This might break the module for Browserify, however - I've not had a chance to test.  It might be better as a fork in that case.

Fixes #44 