### PR TITLE
Replace bulk-require

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -11,16 +11,17 @@
 // DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 // ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-var bulkify = require('bulk-require')
+var requireAll = require('require-all')
 var _ = require('lodash')
 
 module.exports = function () {
-  var totalList = []
-  var fileList = bulkify(__dirname, ['*.json'])
-  _.forEach(fileList, function (file) {
+  var fileData = requireAll({
+    dirname: __dirname,
+    filter: /.+\.json$/
+  })
+  return _.values(fileData).map(function (file) {
     file.ISO[2] = file.ISO.alpha2
     file.ISO[3] = file.ISO.alpha3
-    totalList.push(file)
+    return file
   })
-  return totalList
 }

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "homepage": "https://github.com/therebelrobot/countryjs",
   "dependencies": {
-    "bulk-require": "^1.0.0",
     "lodash": "^4.17.2",
-    "minimatch": "^3.0.3"
+    "minimatch": "^3.0.3",
+    "require-all": "^2.2.0"
   },
   "devDependencies": {
     "chai": "^2.1.0",

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -1,0 +1,37 @@
+var fs = require('fs')
+var path = require('path')
+var expect = require('chai').expect
+var data = require('../data')
+
+/* Definitions for JS Standard */
+/* global describe, it */
+
+describe('data', function () {
+  it('should export a function', function (done) {
+    expect(data).to.be.a('function')
+    done()
+  })
+
+  it('should contain data for every JSON file in the data directory', function (done) {
+    var dataDirectory = path.join(path.dirname(__dirname), 'data')
+    var dataArray = data()
+
+    fs.readdir(dataDirectory, function (err, files) {
+      if (err) {
+        done(err)
+        return
+      }
+
+      var jsonFiles = files.filter(function (file) {
+        return file.endsWith('.json')
+      })
+
+      jsonFiles.forEach(function (file) {
+        var jsonData = require(path.join(dataDirectory, file))
+        expect(dataArray).to.contain(jsonData)
+      })
+    })
+
+    done()
+  })
+})


### PR DESCRIPTION
This replaces the `bulk-require` package with [`require-all`](https://github.com/felixge/node-require-all), which fixes #57 . I started by adding the test `test/data.test.js` to ensure that the updated implementation didn't change anything. A main difference in the two packages is that `require-all` returns an object with file names as keys rather than an array from `bulk-require`, which is addressed in the new implementation in `data/index.js`.