### PR TITLE
Change province names

### DIFF
--- a/data/spain.json
+++ b/data/spain.json
@@ -84,7 +84,7 @@
     "latlng": [40, -4],
     "nativeName": "España",
     "population": 46507760,
-    "provinces": ["A Coruña", "Álava", "Albacete", "Alicante", "Almería", "Asturias", "Ávila", "Badajoz", "Balearic Islands", "Barcelona", "Biscay", "Burgos", "Cáceres", "Cádiz", "Cantabria", "Castellón", "Ciudad Real", "Córdoba", "Cuenca", "Gipuzkoa", "Girona", "Granada", "Guadalajara", "Huelva", "Huesca", "Jaén", "La Rioja", "Las Palmas", "León", "Lleida", "Lugo", "Madrid", "Málaga", "Murcia", "Navarre", "Ourense", "Palencia", "Pontevedra", "Salamanca", "Santa Cruz de Tenerife", "Segovia", "Seville", "Soria", "Tarragona", "Teruel", "Toledo", " Valencia", "Valladolid", "Zamora", "Zaragoza"],
+    "provinces": ["A Coruña", "Álava", "Albacete", "Alicante", "Almería", "Asturias", "Ávila", "Badajoz", "Ceuta", "Islas Baleares", "Barcelona", "Bizkaia", "Burgos", "Cáceres", "Cádiz", "Cantabria", "Castellón", "Ciudad Real", "Córdoba", "Cuenca", "Gipuzkoa", "Girona", "Granada", "Guadalajara", "Huelva", "Huesca", "Jaén", "La Rioja", "Las Palmas", "León", "Lleida", "Lugo", "Madrid", "Málaga", "Melilla", "Murcia", "Navarra", "Ourense", "Palencia", "Pontevedra", "Salamanca", "Santa Cruz de Tenerife", "Segovia", "Sevilla", "Soria", "Tarragona", "Teruel", "Toledo", "Valencia", "Valladolid", "Zamora", "Zaragoza"],
     "region": "Europe",
     "subregion": "Southern Europe",
     "timezones": ["UTC", "UTC+01:00"],


### PR DESCRIPTION
From English to official name:
* Balearic islands -> Islas Baleares
* Biscay -> Bizkaia 
* Navarre -> Navarra
* Seville -> Sevilla

Removed a space character before Valencia
Added autonomous cities of "Ceuta" and "Melilla" in north Africa. If you live there and you are displaying a province combo for Spain you would expect the provinces to list them. Officially Spain has 50 provinces and two autonomous cities.